### PR TITLE
Update custom.css

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -12,11 +12,11 @@
 } */
 
 .usa-link-github {
-  background-image: url('/assets/images/github.png');
+  background-image: url('../assets/images/github.png');
 }
 
 .usa-link-trello {
-  background-image: url('/assets/images/trello-logo.png');
+  background-image: url('/spark-website/assets/images/trello-logo.png');
 }
 
 .usa-link-slack {


### PR DESCRIPTION
try dots and hard hard coding file path

## Issue: <!-- #SOURCE_ISSUE -->
Links for footer logos are pointing to wrong spot
## Approach
Tried prefixing url with two dots and also hard-coded 'spark-website' code
<!-- Describe what you did and why -->

<!--
Please:
* Clearly and concisely name your PR
* Split different bugs/features into different PRs
* Ask Code-dot-mil/code-mil for review
* Ensure the checks pass before asking for review
-->
